### PR TITLE
feat: generate human-readable url path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cgisf_lib"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c89ba5b21d4fbad26deac8ca0a66cb8e6e90e2bb5cf21014134efb8fc62dfd0"
+dependencies = [
+ "const_format",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,6 +558,27 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -1148,6 +1179,21 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330f0e13e6483b8c34885f7e6c9f19b1a7bd449c673fbb948a51c99d66ef74f4"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"
@@ -2149,6 +2195,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2353,7 +2405,9 @@ dependencies = [
 name = "wastebin_core"
 version = "3.0.0"
 dependencies = [
+ "ahash",
  "async-compression",
+ "cgisf_lib",
  "chacha20poly1305",
  "parking_lot",
  "rand 0.9.0",

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ POST a new paste to the `/` endpoint with the following JSON payload:
   "expires": <number of seconds from now, optional>,
   "burn_after_reading": <true/false, optional>,
   "password": <password for encryption optional>,
+  "human_readable": <true/false, generate human-readable url path, optional>,
 }
 ```
 

--- a/crates/wastebin_core/Cargo.toml
+++ b/crates/wastebin_core/Cargo.toml
@@ -6,7 +6,9 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
+ahash = { version = "0.8.11", default-features = false, features = ["std"] }
 async-compression = { version = "0.4", features = ["tokio", "zstd"] }
+cgisf_lib = "0.2.1"
 chacha20poly1305 = "0.10.1"
 parking_lot = "0.12.1"
 rand = "0.9"
@@ -18,6 +20,14 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "rt-multi-thread"] }
 tracing = { workspace = true }
 zstd = "0.13"
+
+[dev-dependencies]
+tokio = { workspace = true, features = [
+    "io-util",
+    "rt-multi-thread",
+    "macros",
+    "time",
+] }
 
 [lints]
 workspace = true

--- a/crates/wastebin_server/src/handlers/download.rs
+++ b/crates/wastebin_server/src/handlers/download.rs
@@ -21,7 +21,7 @@ pub async fn get(
         let key: Key = id.parse()?;
         let password = password.map(|Password(password)| password);
 
-        match db.get(key.id, password).await {
+        match db.get(&key.id, password).await {
             Ok(Entry::Regular(data) | Entry::Burned(data)) => {
                 Ok(get_download(&key, data).into_response())
             }

--- a/crates/wastebin_server/src/handlers/html/paste.rs
+++ b/crates/wastebin_server/src/handlers/html/paste.rs
@@ -49,7 +49,7 @@ pub async fn get<E>(
         let no_password = password.is_none();
         let key: Key = id.parse()?;
 
-        let (data, is_available) = match db.get(key.id, password).await {
+        let (data, is_available) = match db.get(&key.id, password).await {
             Ok(Entry::Regular(data)) => (data, true),
             Ok(Entry::Burned(data)) => (data, false),
             Err(db::Error::NoPassword) => {

--- a/crates/wastebin_server/src/handlers/html/qr.rs
+++ b/crates/wastebin_server/src/handlers/html/qr.rs
@@ -27,7 +27,7 @@ pub async fn get(
                 .map_err(Error::from)??
         };
 
-        let title = db.get_title(key.id).await?;
+        let title = db.get_title(key.id.clone()).await?;
 
         // TODO: fix the bogus hardcoded can_delete and is_deleted fields.
         Ok(Qr {

--- a/crates/wastebin_server/src/handlers/raw.rs
+++ b/crates/wastebin_server/src/handlers/raw.rs
@@ -19,7 +19,7 @@ pub async fn get(
         let password = password.map(|Password(password)| password);
         let key: Key = id.parse()?;
 
-        match db.get(key.id, password).await {
+        match db.get(&key.id, password).await {
             Ok(Entry::Regular(data) | Entry::Burned(data)) => Ok(data.text.into_response()),
             Err(db::Error::NoPassword) => Ok(PasswordInput {
                 page: page.clone(),

--- a/crates/wastebin_server/templates/index.html
+++ b/crates/wastebin_server/templates/index.html
@@ -48,6 +48,12 @@
             </div>
           </div>
           <div class="controls-group">
+            <div class="controls-checkbox-group">
+              <input type="checkbox" name="human-readable" id="human-readable">
+              <label for="human-readable">🧔 readable link</label>
+            </div>
+          </div>
+          <div class="controls-group">
             <div class="controls-row">
               <input type="password" name="password" id="password" placeholder="Password ...">
             </div>


### PR DESCRIPTION
chore: apply clippy lints

build: tests in wastebin_core::db requires tokio/time and tokio/macros

fix: set fixed seed for ahash randomstate

fix: inverted condition of human-readable and normal rand

docs(readme): fix outdated example commands

docs(readme): define API_URl var in example usage

docs(readme): fix commands

feat: human-readable link via webui

enhance: reduce collision rate of human-readable strings

The current random sentence may cause collisions per ~74k requests When random pattern is used (`SentenceConfigBuilder::random().build()`), collisions will only happen per ~200k requests

revert: "enhance: reduce collision rate of human-readable strings"

This reverts commit 37e368ed0ac7d9047b27de2ec88ad03dae38d154.

fix: avoid any id collision

fix: set uid for db_entry before insertion